### PR TITLE
fix: fix version validation

### DIFF
--- a/src/test/verify-parameters.test.js
+++ b/src/test/verify-parameters.test.js
@@ -11,27 +11,40 @@ describe('verifyParameters', () => {
 		});
 	});
 
-	describe('storeName', () => {
-		it('should throw an error if storeName is not an array of string', () => {
-			expect(() => verifyParameters('db', [1], 1)).toThrow('Store name is required and must be an array of strings');
-		});
+        describe('storeName', () => {
+                it('should throw an error if storeName is not an array of string', () => {
+                        expect(() => verifyParameters('db', [1], 1)).toThrow('Store name is required and must be an array of non-empty strings');
+                });
 
-		it('should throw an error if storeName has an element of an array that is not a string', () => {
-			expect(() => verifyParameters('db', ['apple', 'create', 2], 1)).toThrow('Store name is required and must be an array of strings');
-		});
+                it('should throw an error if storeName has an element of an array that is not a string', () => {
+                        expect(() => verifyParameters('db', ['apple', 'create', 2], 1)).toThrow('Store name is required and must be an array of non-empty strings');
+                });
 
-		it('should throw an error if storeName is not provided', () => {
-			expect(() => verifyParameters('db', undefined, 1)).toThrow('Store name is required and must be an array of strings');
-		});
-	});
+                it('should throw an error if storeName has an empty string', () => {
+                        expect(() => verifyParameters('db', [''], 1)).toThrow('Store name is required and must be an array of non-empty strings');
+                });
+
+                it('should throw an error if storeName is not provided', () => {
+                        expect(() => verifyParameters('db', undefined, 1)).toThrow('Store name is required and must be an array of non-empty strings');
+                });
+        });
 
 	describe('version', () => {
-		it('should throw an error if version is not a number', () => {
-			expect(() => verifyParameters('db', ['store'], '1')).toThrow('Version is required and must be a number');
-		});
+                it('should throw an error if version is not a number', () => {
+                        expect(() => verifyParameters('db', ['store'], '1')).toThrow('Version is required and must be a positive integer');
+                });
 
-		it('should throw an error if version is not provided', () => {
-			expect(() => verifyParameters('db', ['store'], undefined)).toThrow('Version is required and must be a number');
-		});
-	});
+                it('should throw an error if version is not provided', () => {
+                        expect(() => verifyParameters('db', ['store'], undefined)).toThrow('Version is required and must be a positive integer');
+                });
+
+                it('should throw an error if version is not an integer', () => {
+                        expect(() => verifyParameters('db', ['store'], 1.1)).toThrow('Version is required and must be a positive integer');
+                });
+
+                it('should throw an error if version is not positive', () => {
+                        expect(() => verifyParameters('db', ['store'], 0)).toThrow('Version is required and must be a positive integer');
+                        expect(() => verifyParameters('db', ['store'], -1)).toThrow('Version is required and must be a positive integer');
+                });
+        });
 });

--- a/src/verify-parameters.js
+++ b/src/verify-parameters.js
@@ -11,13 +11,17 @@ function verifyParameters(databaseName, storeNames, version) {
 		throw new Error('Database name is required and must be a string');
 	}
 
-	if (!Array.isArray(storeNames) || storeNames.length === 0 || !storeNames.every((name) => typeof name === 'string')) {
-		throw new Error('Store name is required and must be an array of strings');
-	}
+       if (
+               !Array.isArray(storeNames) ||
+               storeNames.length === 0 ||
+               !storeNames.every((name) => typeof name === 'string' && name.length > 0)
+       ) {
+               throw new Error('Store name is required and must be an array of non-empty strings');
+       }
 
-	if (typeof version !== 'number') {
-		throw new Error('Version is required and must be a number');
-	}
+        if (!Number.isInteger(version) || version <= 0) {
+                throw new Error('Version is required and must be a positive integer');
+        }
 }
 
 export { verifyParameters };


### PR DESCRIPTION
## Summary
- verify version is a positive integer in `verifyParameters`
- update tests for new validation logic
- validate store names are non-empty strings
- revert package lock changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb0d994dc8332bcb5e35d375a1501