### PR TITLE
Fix version validation in Reign

### DIFF
--- a/src/test/verify-parameters.test.js
+++ b/src/test/verify-parameters.test.js
@@ -27,11 +27,23 @@ describe('verifyParameters', () => {
 
 	describe('version', () => {
 		it('should throw an error if version is not a number', () => {
-			expect(() => verifyParameters('db', ['store'], '1')).toThrow('Version is required and must be a number');
+			expect(() => verifyParameters('db', ['store'], '1')).toThrow('Version is required and must be a positive integer');
 		});
 
 		it('should throw an error if version is not provided', () => {
-			expect(() => verifyParameters('db', ['store'], undefined)).toThrow('Version is required and must be a number');
+			expect(() => verifyParameters('db', ['store'], undefined)).toThrow('Version is required and must be a positive integer');
+		});
+
+		it('should throw an error if version is NaN', () => {
+			expect(() => verifyParameters('db', ['store'], NaN)).toThrow('Version is required and must be a positive integer');
+		});
+
+		it('should throw an error if version is negative', () => {
+			expect(() => verifyParameters('db', ['store'], -1)).toThrow('Version is required and must be a positive integer');
+		});
+
+		it('should throw an error if version is not an integer', () => {
+			expect(() => verifyParameters('db', ['store'], 1.5)).toThrow('Version is required and must be a positive integer');
 		});
 	});
 });

--- a/src/verify-parameters.js
+++ b/src/verify-parameters.js
@@ -15,8 +15,8 @@ function verifyParameters(databaseName, storeNames, version) {
 		throw new Error('Store name is required and must be an array of strings');
 	}
 
-	if (typeof version !== 'number') {
-		throw new Error('Version is required and must be a number');
+	if (typeof version !== 'number' || !Number.isInteger(version) || version <= 0) {
+		throw new Error('Version is required and must be a positive integer');
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate that `version` is a positive integer
- test invalid `version` values: `NaN`, negative numbers and decimals

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_683fb457cfe483328ac507f12c882712