### PR TITLE
Fix delete method return type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Deletes a specific record by its ID from the specified object store.
 - **`storeName`** (`String`): Name of the object store
 - **`id`** (`Number`): The ID of the record to delete
 
-**Returns**: `Promise<undefined>`
+**Returns**: `Promise<void>`
 
 ---
 


### PR DESCRIPTION
## Summary
- correct the described return type for `delete()` in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb4633f548332be1c066d6d2b62e8