### PR TITLE
Fix delete test assert

### DIFF
--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -104,10 +104,10 @@ describe('Reign', () => {
 			expect(record).toBeUndefined();
 		});
 
-		test('should not throw an error when deleting a non-existent ID', async () => {
-			await expect(reign.delete('TestStore1', 999)).resolves.not.toThrow();
-		});
-	});
+                test('should not throw an error when deleting a non-existent ID', async () => {
+                        await expect(reign.delete('TestStore1', 999)).resolves.toBeUndefined();
+                });
+        });
 
 	describe('close method', () => {
 		test('should close the database connection', () => {


### PR DESCRIPTION
## Summary
- check returned promise resolves instead of just not throwing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fb46d81b48332b17dbb0cd33fd4fd