### PR TITLE
Bump version to 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "reign",
-	"version": "1.2.3",
+	"name": "reign-idb",
+       "version": "1.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "reign",
-			"version": "1.2.3",
+			"name": "reign-idb",
+                       "version": "1.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/core": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "reign-idb",
 	"description": "Reign (or `reign-idb` short for Reign IndexedDB) is lightweight library for managing IndexedDB operations in modern web applications.",
-	"version": "1.2.3",
+    "version": "1.2.4",
 	"main": "lib/index.js",
 	"scripts": {
 		"test": "jest",


### PR DESCRIPTION
## Summary
- bump version to 1.2.4 in `package.json`
- synchronize version in `package-lock.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb7e076308332b9ef684b368f5a7a