### PR TITLE
Add isExist helper for checking record presence

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,23 @@ class Reign {
 	}
 
 	/**
+	 * Checks if a record with the specified ID exists in the object store.
+	 *
+	 * @param {String} storeName - The name of the object store.
+	 * @param {number} id - The ID of the record to check.
+	 * @returns {Promise<boolean>} A promise that resolves to true if the record exists, otherwise false.
+	 * @throws {Error} If an error occurs while checking for the record.
+	 */
+	async isExist(storeName, id) {
+		const store = await createTransaction(this.db, storeName, 'readonly');
+		return new Promise((resolve, reject) => {
+			const request = store.get(id);
+			request.onsuccess = () => resolve(request.result !== undefined);
+			request.onerror = (event) => reject(event.target.error);
+		});
+	}
+
+	/**
 	 * Deletes a record by its ID from the specified object store.
 	 *
 	 * @param {String} storeName - The name of the object store.

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -93,6 +93,19 @@ describe('Reign', () => {
 		});
 	});
 
+	describe('isExist method', () => {
+		test('should return true when a record exists in the specified store', async () => {
+			const data = { name: 'Existing Item', value: 55 };
+			const id = await reign.update('TestStore1', data);
+
+			await expect(reign.isExist('TestStore1', id)).resolves.toBe(true);
+		});
+
+		test('should return false when a record does not exist in the specified store', async () => {
+			await expect(reign.isExist('TestStore1', 12345)).resolves.toBe(false);
+		});
+	});
+
 	describe('delete method', () => {
 		test('should delete a record by ID from the specified store', async () => {
 			const data = { name: 'Deletable Item', value: 200 };
@@ -180,6 +193,11 @@ describe('Reign', () => {
 		test('should throw an error when calling get without initializing', async () => {
 			const uninitializedReign = new Reign({ databaseName, storeNames, version });
 			await expect(uninitializedReign.get('TestStore1', 1)).rejects.toThrow('Database is not initialized. Call init() first.');
+		});
+
+		test('should throw an error when calling isExist without initializing', async () => {
+			const uninitializedReign = new Reign({ databaseName, storeNames, version });
+			await expect(uninitializedReign.isExist('TestStore1', 1)).rejects.toThrow('Database is not initialized. Call init() first.');
 		});
 
 		test('should throw an error when calling delete without initializing', async () => {


### PR DESCRIPTION
## Summary
- add an `isExist` helper on `Reign` to check whether a record with a given id exists in a store
- cover the new helper with unit tests and extend error handling tests for uninitialized databases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddfadf74048332a33a12eddea17f86