### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "reign-idb",
-       "version": "1.3.0",
+        "version": "1.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "reign-idb",
-                       "version": "1.3.0",
+                        "version": "1.4.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/core": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "reign-idb",
 	"description": "Reign (or `reign-idb` short for Reign IndexedDB) is lightweight library for managing IndexedDB operations in modern web applications.",
-    "version": "1.3.1",
+    "version": "1.4.0",
 	"main": "lib/index.js",
 	"scripts": {
 		"test": "jest",


### PR DESCRIPTION
## Summary
- bump the published package version metadata to 1.4.0 in both package.json and package-lock.json

## Testing
- `jest`


------
https://chatgpt.com/codex/tasks/task_e_68de0183bd4c83329df6089697b1ea35